### PR TITLE
feat: feat: Pipeline event hooks — dashboard 실시간 이벤트 전송

### DIFF
--- a/orchestrator/handlers.py
+++ b/orchestrator/handlers.py
@@ -1151,6 +1151,7 @@ async def _solve_single_issue(
     solve_mode: str | None = None,
     scheduler=None,
     supreme_court_cb=None,
+    dashboard_client=None,
 ) -> tuple[str, str]:
     """Solve one issue. Routes to fivebrid, dual-check, or direct-claude based on settings."""
     settings = context.bot_data["settings"]
@@ -1163,6 +1164,8 @@ async def _solve_single_issue(
         return "failed", "Pipeline requires Ollama but it is not configured"
     if not gemini:
         return "failed", "Pipeline requires Gemini CLI but it is not available"
+    if dashboard_client is None:
+        dashboard_client = context.bot_data.get("dashboard")
     return await _solve_with_fivebrid(
         context, chat_id, project_name, project_path,
         issue_num, timeout, cancel_event,
@@ -1171,6 +1174,7 @@ async def _solve_single_issue(
         solve_mode=solve_mode,
         scheduler=scheduler,
         supreme_court_cb=supreme_court_cb,
+        dashboard_client=dashboard_client,
     )
 
 
@@ -1189,6 +1193,7 @@ async def _solve_with_fivebrid(
     solve_mode: str | None = None,
     scheduler=None,
     supreme_court_cb=None,
+    dashboard_client=None,
 ) -> tuple[str, str]:
     """Solve via adaptive Five-brid pipeline."""
     branch_name = f"solve/issue-{issue_num}"
@@ -1359,6 +1364,7 @@ async def _solve_with_fivebrid(
             project_info=project_info,
             scheduler=scheduler,
             supreme_court_cb=supreme_court_cb,
+            dashboard_client=dashboard_client,
         )
 
         elapsed = int(time.monotonic() - pipeline_start)

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -14,7 +14,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 import httpx
 
@@ -24,11 +24,42 @@ from .ai.ollama_provider import OllamaProvider
 from .config import PIPELINE_MODES, Settings
 from .security import mask_secrets
 
+if TYPE_CHECKING:
+    from .dashboard_client import DashboardClient
+
 logger = logging.getLogger(__name__)
 
 # ── Data Structures ──────────────────────────────────────────────────────────
 
 ProgressCallback = Callable[[str], Awaitable[None]]
+
+_STEP_AGENT_MAP: dict[str, str] = {
+    "Haiku Research": "haiku-researcher",
+    "Opus Design": "opus-designer",
+    "Gemini Design Critique": "gemini-reviewer",
+    "Qwen Hints": "qwen-worker",
+    "Sonnet Implement": "sonnet-worker",
+    "Local CI Check": "orchestrator",
+    "Sonnet Self-Review": "sonnet-worker",
+    "Gemini Cross-Review": "gemini-reviewer",
+    "AI Audit": "deepseek-auditor",
+    "Data Mining": "qwen-worker",
+}
+
+
+async def _notify_step(
+    dashboard_client: "DashboardClient | None", step_name: str, status: str,
+) -> None:
+    if dashboard_client is None:
+        return
+    agent_id = _STEP_AGENT_MAP.get(step_name)
+    if not agent_id:
+        logger.debug("No agent mapping for step %r, skipping notification", step_name)
+        return
+    try:
+        await dashboard_client.update_agent_status(agent_id, status)
+    except Exception:
+        logger.warning("Failed to notify dashboard for %s → %s", agent_id, status, exc_info=True)
 
 
 @dataclass
@@ -1654,6 +1685,7 @@ async def run_fivebrid_pipeline(
     resume_from_step: int = -1,
     scheduler: "StaggeredScheduler | None" = None,
     supreme_court_cb: Callable | None = None,
+    dashboard_client: "DashboardClient | None" = None,
 ) -> tuple[str, str]:
     """Run the adaptive Five-brid pipeline. Returns (status, detail)."""
     from .scheduler import StaggeredScheduler  # noqa: F811
@@ -1681,6 +1713,17 @@ async def run_fivebrid_pipeline(
         return next((i for i, s in enumerate(ctx.steps) if s.name == name), None)
 
     try:
+        if dashboard_client:
+            try:
+                await dashboard_client.send_event("PIPELINE_STARTED", {
+                    "issue_num": ctx.issue_num,
+                    "mode": ctx.mode,
+                    "project_name": ctx.project_name,
+                })
+                logger.debug("Dashboard: PIPELINE_STARTED for issue #%s", ctx.issue_num)
+            except Exception:
+                logger.warning("Failed to send PIPELINE_STARTED event", exc_info=True)
+
         # Fetch issue (skip if already populated by triage or checkpoint)
         if ctx.issue_body:
             if resuming:
@@ -1701,7 +1744,9 @@ async def run_fivebrid_pipeline(
                 await progress_cb(f"[{research_idx}/{total_steps}] Haiku Research (cached)")
             else:
                 await progress_cb(f"[{research_idx}/{total_steps}] Haiku Research...")
+                await _notify_step(dashboard_client, "Haiku Research", "RUNNING")
                 await step_haiku_research(ctx, settings, progress_cb, step_index=research_idx)
+                await _notify_step(dashboard_client, "Haiku Research", "IDLE")
 
             if cancel_event.is_set():
                 return "skipped", "Cancelled by user"
@@ -1737,7 +1782,9 @@ async def run_fivebrid_pipeline(
                         total_steps = len(ctx.steps)
 
                     current_design_idx = design_idx + (iteration * 2)
+                    await _notify_step(dashboard_client, "Opus Design", "RUNNING")
                     await step_opus_design(ctx, settings, progress_cb, step_index=current_design_idx)
+                    await _notify_step(dashboard_client, "Opus Design", "IDLE")
 
                     if cancel_event.is_set():
                         return "skipped", "Cancelled by user"
@@ -1747,9 +1794,11 @@ async def run_fivebrid_pipeline(
                     if critique_idx is not None:
                         current_critique_idx = current_design_idx + 1
                         await progress_cb(f"[{current_critique_idx}/{total_steps}] Gemini Design Critique{step_label}...")
+                        await _notify_step(dashboard_client, "Gemini Design Critique", "RUNNING")
                         await step_gemini_design_critique(
                             ctx, gemini, settings, progress_cb, step_index=current_critique_idx,
                         )
+                        await _notify_step(dashboard_client, "Gemini Design Critique", "IDLE")
 
                         critique_step = ctx.steps[current_critique_idx]
                         if critique_step.status == "revised" and "NEEDS_REVISION" in critique_step.detail:
@@ -1776,11 +1825,14 @@ async def run_fivebrid_pipeline(
             if _step_done(qwen_idx):
                 await progress_cb(f"[{qwen_idx}/{total_steps}] Qwen Pre-Implement (cached)")
             else:
+                await _notify_step(dashboard_client, "Qwen Hints", "RUNNING")
                 try:
                     await progress_cb(f"[{qwen_idx}/{total_steps}] Qwen Pre-Implement...")
                     await step_qwen_pre_implement(ctx, ollama, settings, progress_cb, step_index=qwen_idx)
                 except Exception as exc:
                     logger.warning("Qwen pre-implement failed (non-fatal): %s", exc)
+                finally:
+                    await _notify_step(dashboard_client, "Qwen Hints", "IDLE")
 
             if cancel_event.is_set():
                 return "skipped", "Cancelled by user"
@@ -1794,7 +1846,9 @@ async def run_fivebrid_pipeline(
             await progress_cb(f"[{impl_idx}/{total_steps}] Sonnet Implement (cached)")
         else:
             await progress_cb(f"[{impl_idx}/{total_steps}] Sonnet Implement...")
+            await _notify_step(dashboard_client, "Sonnet Implement", "RUNNING")
             await step_claude_implement(ctx, settings, cancel_event, progress_cb, step_index=impl_idx)
+            await _notify_step(dashboard_client, "Sonnet Implement", "IDLE")
 
         # Capture snapshot ref for safe-fail recovery
         if not (resuming and ctx.impl_snapshot_ref):
@@ -1830,8 +1884,10 @@ async def run_fivebrid_pipeline(
                 await progress_cb(f"[{ci_idx}/{total_steps}] Local CI Check (cached)")
             else:
                 await progress_cb(f"[{ci_idx}/{total_steps}] Local CI Check...")
+                await _notify_step(dashboard_client, "Local CI Check", "RUNNING")
                 await step_local_ci_check(ctx, settings, progress_cb, ci_commands,
                                           step_index=ci_idx, max_retries_override=effective_ci_fix_retries)
+                await _notify_step(dashboard_client, "Local CI Check", "IDLE")
 
             if cancel_event.is_set():
                 return "skipped", "Cancelled by user"
@@ -1843,7 +1899,9 @@ async def run_fivebrid_pipeline(
                 await progress_cb(f"[{self_review_idx}/{total_steps}] Sonnet Self-Review (cached)")
             else:
                 await progress_cb(f"[{self_review_idx}/{total_steps}] Sonnet Self-Review...")
+                await _notify_step(dashboard_client, "Sonnet Self-Review", "RUNNING")
                 await step_sonnet_self_review(ctx, settings, cancel_event, progress_cb, step_index=self_review_idx)
+                await _notify_step(dashboard_client, "Sonnet Self-Review", "IDLE")
 
             if cancel_event.is_set():
                 return "skipped", "Cancelled by user"
@@ -1857,7 +1915,9 @@ async def run_fivebrid_pipeline(
                 await progress_cb(f"[{cross_review_idx}/{total_steps}] Gemini Cross-Review (cached)")
             else:
                 await progress_cb(f"[{cross_review_idx}/{total_steps}] Gemini Cross-Review...")
+                await _notify_step(dashboard_client, "Gemini Cross-Review", "RUNNING")
                 await step_gemini_cross_review(ctx, gemini, settings, progress_cb, step_index=cross_review_idx)
+                await _notify_step(dashboard_client, "Gemini Cross-Review", "IDLE")
 
             if cancel_event.is_set():
                 return "skipped", "Cancelled by user"
@@ -1887,7 +1947,9 @@ async def run_fivebrid_pipeline(
                 await progress_cb(f"[{audit_idx}/{total_steps}] AI Audit{audit_label}...")
 
                 try:
+                    await _notify_step(dashboard_client, "AI Audit", "RUNNING")
                     await step_ai_audit(ctx, ollama, settings, progress_cb, step_index=audit_idx)
+                    await _notify_step(dashboard_client, "AI Audit", "IDLE")
                     break  # PASS
                 except RuntimeError:
                     # Supreme Court: self-review PASS vs audit FAIL
@@ -1917,11 +1979,14 @@ async def run_fivebrid_pipeline(
                         )
                         ctx.review_feedback = ctx.ai_audit_result
 
+                        await _notify_step(dashboard_client, "AI Audit", "IDLE")
                         await progress_cb(f"AI Audit FAIL — Sonnet re-implementing (retry {audit_attempt + 1})...")
                         if ctx.impl_snapshot_ref:
                             await _reset_to_snapshot(ctx.project_path, ctx.impl_snapshot_ref)
 
+                        await _notify_step(dashboard_client, "Sonnet Implement", "RUNNING")
                         await step_claude_implement(ctx, settings, cancel_event, progress_cb, step_index=impl_idx)
+                        await _notify_step(dashboard_client, "Sonnet Implement", "IDLE")
                         await _snapshot_commit(ctx.project_path, ctx.issue_num)
                         ctx.git_diff = await _capture_filtered_diff(
                             ctx.project_path, base_ref=ctx.base_commit or "main",
@@ -1960,15 +2025,39 @@ async def run_fivebrid_pipeline(
                 data_mining_idx = len(ctx.steps) - 1
             try:
                 await progress_cb(f"[{data_mining_idx}/{len(ctx.steps)}] Data Mining...")
+                await _notify_step(dashboard_client, "Data Mining", "RUNNING")
                 await step_data_mining_fivebrid(ctx, ollama, settings, progress_cb, step_index=data_mining_idx)
+                await _notify_step(dashboard_client, "Data Mining", "IDLE")
             except Exception as exc:
+                await _notify_step(dashboard_client, "Data Mining", "IDLE")
                 logger.warning("Data mining step failed (non-fatal): %s", exc)
 
+        if dashboard_client:
+            try:
+                await dashboard_client.send_event("PIPELINE_COMPLETED", {
+                    "status": "success",
+                })
+                logger.debug("Dashboard: PIPELINE_COMPLETED for issue #%s", ctx.issue_num)
+            except Exception:
+                logger.warning("Failed to send PIPELINE_COMPLETED event", exc_info=True)
         return "success", "All checks passed"
 
     except asyncio.CancelledError:
         return "skipped", "Cancelled by user"
     except Exception as exc:
+        if dashboard_client:
+            failed_step = next(
+                (s.name for s in reversed(ctx.steps) if s.status == "failed"),
+                "unknown",
+            )
+            try:
+                await dashboard_client.send_event("ERROR", {
+                    "failed_step": failed_step,
+                    "error_detail": str(exc)[:200],
+                })
+                logger.debug("Dashboard: ERROR event for issue #%s — %s", ctx.issue_num, failed_step)
+            except Exception:
+                logger.warning("Failed to send ERROR event", exc_info=True)
         for s in reversed(ctx.steps):
             if s.status == "failed":
                 return "failed", f"{s.name}: {s.detail}"

--- a/tests/test_pipeline_events.py
+++ b/tests/test_pipeline_events.py
@@ -1,0 +1,368 @@
+"""Tests for pipeline event hooks — dashboard integration."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestrator.pipeline import (
+    PipelineStep,
+    _STEP_AGENT_MAP,
+    _notify_step,
+    run_fivebrid_pipeline,
+    PipelineContext,
+)
+
+
+@pytest.fixture
+def mock_dashboard():
+    client = AsyncMock()
+    client.update_agent_status = AsyncMock()
+    client.send_event = AsyncMock()
+    client.create_pipeline_run = AsyncMock(return_value="run-123")
+    client.update_pipeline_run = AsyncMock()
+    return client
+
+
+def _make_ctx(**overrides):
+    """Build a minimal PipelineContext for testing."""
+    defaults = dict(
+        project_path="/tmp/test",
+        project_name="test-project",
+        issue_num=42,
+        branch_name="solve/issue-42",
+        mode="standard",
+        issue_body="test body",
+        issue_title="test title",
+    )
+    defaults.update(overrides)
+    return PipelineContext(**defaults)
+
+
+def _pipeline_patches(extra_step_patches=None):
+    """Common patches for running the pipeline in tests."""
+    import contextlib
+
+    patches = [
+        patch("orchestrator.pipeline.step_fetch_issue", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_haiku_research", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_opus_design", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_gemini_design_critique", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_qwen_pre_implement", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_claude_implement", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_sonnet_self_review", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_gemini_cross_review", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_ai_audit", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_data_mining_fivebrid", new_callable=AsyncMock),
+        patch("orchestrator.pipeline.step_local_ci_check", new_callable=AsyncMock),
+        patch("orchestrator.pipeline._capture_filtered_diff", new_callable=AsyncMock, return_value="diff"),
+        patch("orchestrator.pipeline.build_fivebrid_steps"),
+        patch("orchestrator.pipeline._resolve_ci_commands", return_value=[]),
+        patch("orchestrator.state_sync.format_state_context", return_value=""),
+        patch("orchestrator.state_sync.append_project_summary"),
+        patch("orchestrator.pipeline._extract_decisions_llm", new_callable=AsyncMock, return_value=""),
+        patch("orchestrator.pipeline._extract_files_from_diff", return_value=[]),
+        patch("orchestrator.pipeline.PIPELINE_MODES", {
+            "standard": {
+                "max_design_retries": 0,
+                "ai_audit_max_retries": 0,
+                "ai_audit_enabled": False,
+                "local_ci_fix_retries": 0,
+            },
+        }),
+    ]
+    if extra_step_patches:
+        patches.extend(extra_step_patches)
+    return contextlib.ExitStack(), patches
+
+
+async def _run_pipeline_with_mocks(ctx, mock_dashboard=None, resume_from_step=-1, build_steps=None):
+    """Helper to run the pipeline with all steps mocked."""
+    stack, patches = _pipeline_patches()
+    cancel = asyncio.Event()
+    progress = AsyncMock()
+    settings = MagicMock()
+    settings.local_ci_enabled = False
+    settings.enable_data_mining = False
+
+    with stack:
+        mocks = {}
+        for p in patches:
+            m = stack.enter_context(p)
+            # Track named mocks
+            attr = getattr(p, 'attribute', None)
+            if attr:
+                mocks[attr] = m
+
+        # Setup build_fivebrid_steps
+        if build_steps is None:
+            build_steps = [
+                PipelineStep(name="Haiku Research"),
+                PipelineStep(name="Opus Design"),
+                PipelineStep(name="Gemini Design Critique"),
+                PipelineStep(name="Sonnet Implement"),
+            ]
+        mocks.get("build_fivebrid_steps", MagicMock()).return_value = build_steps
+
+        # Make step_claude_implement set git_diff
+        impl_mock = mocks.get("step_claude_implement")
+        if impl_mock:
+            async def fake_implement(ctx, *a, **kw):
+                ctx.git_diff = "some diff"
+            impl_mock.side_effect = fake_implement
+
+        # Mock subprocess for git rev-parse
+        with patch("orchestrator.pipeline.asyncio.create_subprocess_exec") as mock_proc:
+            proc_mock = AsyncMock()
+            proc_mock.communicate = AsyncMock(return_value=(b"abc123", b""))
+            mock_proc.return_value = proc_mock
+
+            status, detail = await run_fivebrid_pipeline(
+                ctx, AsyncMock(), AsyncMock(), settings, cancel, progress,
+                dashboard_client=mock_dashboard,
+                resume_from_step=resume_from_step,
+            )
+
+    return status, detail
+
+
+@pytest.mark.asyncio
+async def test_notify_step_calls_update_agent_status(mock_dashboard):
+    await _notify_step(mock_dashboard, "Haiku Research", "RUNNING")
+    mock_dashboard.update_agent_status.assert_awaited_once_with("haiku-researcher", "RUNNING")
+
+
+@pytest.mark.asyncio
+async def test_notify_step_noop_when_client_is_none():
+    await _notify_step(None, "Haiku Research", "RUNNING")
+
+
+@pytest.mark.asyncio
+async def test_notify_step_noop_for_unknown_step(mock_dashboard):
+    await _notify_step(mock_dashboard, "Unknown Step", "RUNNING")
+    mock_dashboard.update_agent_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_step_all_mapped_steps(mock_dashboard):
+    """Verify every entry in _STEP_AGENT_MAP is callable via _notify_step."""
+    for step_name, agent_id in _STEP_AGENT_MAP.items():
+        mock_dashboard.reset_mock()
+        await _notify_step(mock_dashboard, step_name, "RUNNING")
+        mock_dashboard.update_agent_status.assert_awaited_once_with(agent_id, "RUNNING")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_started_event(mock_dashboard):
+    """PIPELINE_STARTED event sent at pipeline start."""
+    ctx = _make_ctx()
+    status, _ = await _run_pipeline_with_mocks(ctx, mock_dashboard=mock_dashboard)
+
+    calls = [c for c in mock_dashboard.send_event.call_args_list if c.args[0] == "PIPELINE_STARTED"]
+    assert len(calls) == 1
+    event_data = calls[0].args[1]
+    assert event_data["issue_num"] == 42
+    assert event_data["mode"] == "standard"
+    assert event_data["project_name"] == "test-project"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_completed_event(mock_dashboard):
+    """PIPELINE_COMPLETED event sent on success."""
+    ctx = _make_ctx()
+    status, _ = await _run_pipeline_with_mocks(ctx, mock_dashboard=mock_dashboard)
+
+    assert status == "success"
+    calls = [c for c in mock_dashboard.send_event.call_args_list if c.args[0] == "PIPELINE_COMPLETED"]
+    assert len(calls) == 1
+    assert calls[0].args[1]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_error_event_on_exception(mock_dashboard):
+    """ERROR event sent on pipeline exception."""
+    ctx = _make_ctx()
+    cancel = asyncio.Event()
+    progress = AsyncMock()
+    settings = MagicMock()
+    settings.local_ci_enabled = False
+    settings.enable_data_mining = False
+
+    with patch("orchestrator.pipeline.step_fetch_issue", new_callable=AsyncMock), \
+         patch("orchestrator.pipeline.step_haiku_research", side_effect=RuntimeError("boom")), \
+         patch("orchestrator.pipeline.build_fivebrid_steps") as mock_build, \
+         patch("orchestrator.pipeline._resolve_ci_commands", return_value=[]), \
+         patch("orchestrator.state_sync.format_state_context", return_value=""), \
+         patch("orchestrator.pipeline.PIPELINE_MODES", {"standard": {"max_design_retries": 0, "ai_audit_max_retries": 0, "ai_audit_enabled": False, "local_ci_fix_retries": 0}}):
+
+        mock_build.return_value = [
+            PipelineStep(name="Haiku Research"),
+            PipelineStep(name="Opus Design"),
+            PipelineStep(name="Sonnet Implement"),
+        ]
+
+        status, _ = await run_fivebrid_pipeline(
+            ctx, AsyncMock(), AsyncMock(), settings, cancel, progress,
+            dashboard_client=mock_dashboard,
+        )
+
+    assert status == "failed"
+    calls = [c for c in mock_dashboard.send_event.call_args_list if c.args[0] == "ERROR"]
+    assert len(calls) == 1
+    assert "error_detail" in calls[0].args[1]
+
+
+@pytest.mark.asyncio
+async def test_no_events_when_dashboard_is_none():
+    """Backward compat: no crash when dashboard_client is None."""
+    ctx = _make_ctx()
+    status, _ = await _run_pipeline_with_mocks(ctx, mock_dashboard=None)
+    assert status == "success"
+
+
+@pytest.mark.asyncio
+async def test_steps_send_running_and_idle(mock_dashboard):
+    """Each step sends RUNNING before and IDLE after execution."""
+    ctx = _make_ctx()
+    await _run_pipeline_with_mocks(ctx, mock_dashboard=mock_dashboard)
+
+    status_calls = mock_dashboard.update_agent_status.call_args_list
+    agent_transitions = [(c.args[0], c.args[1]) for c in status_calls]
+
+    # Haiku Research
+    assert ("haiku-researcher", "RUNNING") in agent_transitions
+    assert ("haiku-researcher", "IDLE") in agent_transitions
+
+    # Opus Design
+    assert ("opus-designer", "RUNNING") in agent_transitions
+    assert ("opus-designer", "IDLE") in agent_transitions
+
+    # Gemini Design Critique
+    assert ("gemini-reviewer", "RUNNING") in agent_transitions
+    assert ("gemini-reviewer", "IDLE") in agent_transitions
+
+    # Sonnet Implement
+    assert ("sonnet-worker", "RUNNING") in agent_transitions
+    assert ("sonnet-worker", "IDLE") in agent_transitions
+
+    haiku_running_idx = agent_transitions.index(("haiku-researcher", "RUNNING"))
+    haiku_idle_idx = agent_transitions.index(("haiku-researcher", "IDLE"))
+    assert haiku_running_idx < haiku_idle_idx
+
+
+@pytest.mark.asyncio
+async def test_cached_steps_skip_running_idle(mock_dashboard):
+    """Cached/resumed steps do NOT send RUNNING/IDLE."""
+    ctx = _make_ctx()
+    ctx.steps = [
+        PipelineStep(name="Haiku Research", status="passed"),
+        PipelineStep(name="Opus Design", status="passed"),
+        PipelineStep(name="Gemini Design Critique", status="passed"),
+        PipelineStep(name="Sonnet Implement"),
+    ]
+
+    await _run_pipeline_with_mocks(ctx, mock_dashboard=mock_dashboard, resume_from_step=3)
+
+    status_calls = mock_dashboard.update_agent_status.call_args_list
+    agent_transitions = [(c.args[0], c.args[1]) for c in status_calls]
+
+    # Haiku, Opus, Gemini Critique should NOT have RUNNING/IDLE (cached)
+    assert ("haiku-researcher", "RUNNING") not in agent_transitions
+    assert ("opus-designer", "RUNNING") not in agent_transitions
+
+    # Sonnet Implement should still have RUNNING/IDLE (not cached)
+    assert ("sonnet-worker", "RUNNING") in agent_transitions
+    assert ("sonnet-worker", "IDLE") in agent_transitions
+
+
+@pytest.mark.asyncio
+async def test_solve_with_fivebrid_passes_dashboard_client(mock_dashboard):
+    """_solve_with_fivebrid passes dashboard_client to run_fivebrid_pipeline."""
+    from orchestrator.handlers import _solve_with_fivebrid
+
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    context.bot.edit_message_text = AsyncMock()
+    settings = MagicMock()
+    settings.solve_mode = "auto"
+    context.bot_data = {"settings": settings, "dashboard": mock_dashboard}
+
+    with patch("orchestrator.handlers._git_fresh_start", new_callable=AsyncMock, return_value=(True, "/tmp/wt")), \
+         patch("orchestrator.handlers.step_triage_and_split", new_callable=AsyncMock, return_value={"mode": "standard", "split_needed": False, "reason": "ok", "sub_issues": [], "estimated_files": ""}), \
+         patch("orchestrator.handlers.run_fivebrid_pipeline", new_callable=AsyncMock, return_value=("success", "done")) as mock_run, \
+         patch("orchestrator.handlers._create_pr", new_callable=AsyncMock, return_value="http://pr"), \
+         patch("orchestrator.handlers.format_pipeline_summary", return_value="summary"), \
+         patch("orchestrator.handlers.get_system_status", new_callable=AsyncMock), \
+         patch("orchestrator.handlers.PIPELINE_MODES", {"standard": {"description": "Standard", "label": "std", "estimated_minutes": (5, 10)}}), \
+         patch("orchestrator.handlers.asyncio.create_subprocess_exec") as mock_proc:
+
+        proc_mock = AsyncMock()
+        proc_mock.communicate = AsyncMock(return_value=(b"abc123", b""))
+        mock_proc.return_value = proc_mock
+
+        fivebrid_settings = MagicMock()
+        fivebrid_settings.solve_mode = "auto"
+        fivebrid_settings.strategy_approval_timeout = 300
+
+        await _solve_with_fivebrid(
+            context, 1, "proj", "/tmp/proj", 42, 600,
+            asyncio.Event(), AsyncMock(), AsyncMock(), fivebrid_settings,
+            dashboard_client=mock_dashboard,
+        )
+
+        mock_run.assert_awaited_once()
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("dashboard_client") is mock_dashboard
+
+
+@pytest.mark.asyncio
+async def test_solve_single_issue_passes_dashboard_client(mock_dashboard):
+    """_solve_single_issue passes dashboard_client to _solve_with_fivebrid."""
+    from orchestrator.handlers import _solve_single_issue
+
+    context = MagicMock()
+    context.bot_data = {
+        "settings": MagicMock(),
+        "projects": {"proj": {}},
+        "ollama": AsyncMock(),
+        "gemini": AsyncMock(),
+        "dashboard": mock_dashboard,
+    }
+
+    with patch("orchestrator.handlers._solve_with_fivebrid", new_callable=AsyncMock, return_value=("success", "done")) as mock_solve:
+        await _solve_single_issue(
+            context, 1, "proj", "/tmp/proj", 42, 600,
+            asyncio.Event(),
+            dashboard_client=mock_dashboard,
+        )
+
+        mock_solve.assert_awaited_once()
+        call_kwargs = mock_solve.call_args.kwargs
+        assert call_kwargs.get("dashboard_client") is mock_dashboard
+
+
+@pytest.mark.asyncio
+async def test_no_crash_when_bot_data_has_no_dashboard():
+    """When bot_data has no 'dashboard' key, None is passed (no crash)."""
+    from orchestrator.handlers import _solve_single_issue
+
+    context = MagicMock()
+    context.bot_data = {
+        "settings": MagicMock(),
+        "projects": {"proj": {}},
+        "ollama": AsyncMock(),
+        "gemini": AsyncMock(),
+    }
+
+    with patch("orchestrator.handlers._solve_with_fivebrid", new_callable=AsyncMock, return_value=("success", "done")) as mock_solve:
+        await _solve_single_issue(
+            context, 1, "proj", "/tmp/proj", 42, 600,
+            asyncio.Event(),
+        )
+
+        mock_solve.assert_awaited_once()
+        call_kwargs = mock_solve.call_args.kwargs
+        assert call_kwargs.get("dashboard_client") is None


### PR DESCRIPTION
Closes #2

## Design
Now I have everything needed. Here's the implementation plan:

---

# Implementation Plan: Pipeline Event Hooks (Issue #2)

## Files to Modify

| File | Change |
|------|--------|
| `orchestrator/pipeline.py` | Add `dashboard_client` parameter, emit RUNNING/IDLE + pipeline-level events |
| `orchestrator/handlers.py` | Thread `dashboard_client` through `_solve_single_issue` → `_solve_with_fivebrid` → `run_fivebrid_pipeline` |
| `tests/test_pipeline_events.py` | **New file** — TDD tests for event hook integration |

## 1. Agent ID Mapping (constant)

Define in `pipeline.py` near line 30, alongside `ProgressCallback`:

```python
# Step name → dashboard agent_id
_STEP_AGENT_MAP: dict[str, str] = {
    "Haiku Research": "haiku-researcher",
    "Opus Design": "opus-designer",
    "Gemini Design Critique": "gemini-reviewer",
    "Qwen Hints": "qwen-worker",
    "Sonnet Implement": "sonnet-worker",
    "Local CI Check": "orchestrator",
    "Sonnet Self-Review": "sonnet-worker",
    "Gemini Cross-Review": "gemini-reviewer",
    "AI Audit": "deepseek-auditor",
    "Data Mining": "qwen-worker",
}
```

## 2. TDD Test Plan — Write FIRST

Create `tests/test_pipeline_events.py`. All tests use `AsyncMock` for the dashboard client — no HTTP mocking needed since we test the *integration wiring*, not the client itself.

### Test Group A: `_notify_step` helper

```python
# A1: _notify_step calls update_agent_status with correct agent_id and status
# A2: _notify_step does nothing when dashboard_c

_(truncated)_

## Changed Files (3)
- `orchestrator/handlers.py`
- `orchestrator/pipeline.py`
- `tests/test_pipeline_events.py`

## Review
The implementation is reviewed against the provided specification and design document.

### 1. Business Logic Correctness
The code correctly implements the required functionality.
-   A `_STEP_AGENT_MAP` constant is added to `pipeline.py` to map human-readable step names to machine-readable `agent_id`s, as specified.
-   A helper function, `_notify_step`, is introduced to encapsulate the logic of sending status updates. It correctly checks for the existence of the `dashboard_client` and the presence of the step in the map, preventing errors.
-   `run_fivebrid_pipeline` is modified to accept `dashboard_client`.
-   Pipeline-level events (`PIPELINE_STARTED`, `PIPELINE_COMPLETED`, `ERROR`) are sent at the correct moments in the pipeline's lifecycle.
-   Step-level events (`RUNNING`, `IDLE`) a

_(truncated)_

## AI Audit: PASS
### Audit Results

#### 1. Intent Alignment
The implementation fully satisfies the issue requirements. All specified functionality is implemented, including:
- Step-agent mapping
- Pipeline-level events
- Step-level RUNNING/IDLE notifications
- Proper error handling
- Backward compatibility

#### 2. Logic Flaws
No critical edge cases were missed. The implementation handles:
- Cached steps
- Non-fatal failures
- Retry loops
- User cancellation
- Null dashboard_client

#### 3. Security
No security vulnerabilities were introduced. The code does not handle user input directly and properly isolates dashboard client operations.

#### 4. Guideline Violations
The code adheres to project conventions and follows PEP 8 style guidelines.

#### 5. Comment Audit

| File | Line | Comment | Issue |
|------|------|---------|-------|
| `orchestrator/pipeline.py` | 1704 | `# Before:` | [MAJOR] Useless comment. Delete. |
| `orchestrator/pipeline.py` | 1705 | `# After:` | [MAJOR] Useless comment. Delete. |

_(truncated)_