### PR TITLE
feat: FastAPI 서버 설정 + API Key 인증 미들웨어

### DIFF
--- a/orchestrator/__main__.py
+++ b/orchestrator/__main__.py
@@ -1,11 +1,17 @@
 """Entrypoint: python -m orchestrator"""
 
+import asyncio
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+import uvicorn
+
+from .api.app import create_api_app
 from .bot import create_application
 from .config import Settings
+
+logger = logging.getLogger(__name__)
 
 
 def setup_logging(level: str) -> None:
@@ -14,7 +20,7 @@ def setup_logging(level: str) -> None:
 
     handler = RotatingFileHandler(
         log_dir / "orchestrator.log",
-        maxBytes=10_485_760,  # 10 MB
+        maxBytes=10_485_760,
         backupCount=5,
     )
     handler.setFormatter(
@@ -27,12 +33,36 @@ def setup_logging(level: str) -> None:
     root.addHandler(logging.StreamHandler())
 
 
+async def run_all(settings: Settings) -> None:
+    telegram_app = create_application(settings)
+
+    api_app = create_api_app(settings)
+    config = uvicorn.Config(
+        api_app, host="0.0.0.0", port=settings.api_port, log_level="info"
+    )
+    server = uvicorn.Server(config)
+
+    async with telegram_app:
+        await telegram_app.start()
+        await telegram_app.updater.start_polling()
+
+        try:
+            await server.serve()
+        finally:
+            try:
+                await telegram_app.updater.stop()
+            except Exception:
+                logger.exception("Error stopping Telegram updater")
+            try:
+                await telegram_app.stop()
+            except Exception:
+                logger.exception("Error stopping Telegram app")
+
+
 def main() -> None:
     settings = Settings()
     setup_logging(settings.log_level)
-
-    app = create_application(settings)
-    app.run_polling()
+    asyncio.run(run_all(settings))
 
 
 if __name__ == "__main__":

--- a/orchestrator/api/__init__.py
+++ b/orchestrator/api/__init__.py
@@ -1,0 +1,3 @@
+from .app import create_api_app
+
+__all__ = ["create_api_app"]

--- a/orchestrator/api/app.py
+++ b/orchestrator/api/app.py
@@ -1,0 +1,46 @@
+import logging
+from urllib.parse import urlparse
+
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+
+from orchestrator.config import Settings
+
+from .auth import APIKeyAuthMiddleware
+from .routes import router
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_cors_origins(raw: str) -> list[str]:
+    origins = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parsed = urlparse(entry)
+        if parsed.scheme and parsed.netloc:
+            origins.append(entry)
+        else:
+            logger.warning("Ignoring invalid CORS origin: %s", entry)
+    return origins
+
+
+def create_api_app(settings: Settings) -> FastAPI:
+    app = FastAPI(title="AI Orchestrator API")
+
+    if settings.cors_origins:
+        origins = _parse_cors_origins(settings.cors_origins)
+        if origins:
+            app.add_middleware(
+                CORSMiddleware,
+                allow_origins=origins,
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
+
+    app.add_middleware(APIKeyAuthMiddleware, api_key=settings.dashboard_api_key)
+    app.include_router(router)
+
+    return app

--- a/orchestrator/api/auth.py
+++ b/orchestrator/api/auth.py
@@ -1,0 +1,55 @@
+import hmac
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+_LOCALHOST_ADDRESSES = ("127.0.0.1", "::1")
+
+
+class APIKeyAuthMiddleware(BaseHTTPMiddleware):
+    PUBLIC_PATHS = {"/api/health"}
+
+    def __init__(self, app, api_key: str = "") -> None:
+        super().__init__(app)
+        self.api_key = api_key
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in self.PUBLIC_PATHS:
+            return await call_next(request)
+
+        auth_header = request.headers.get("authorization")
+
+        if self.api_key:
+            if not auth_header or not auth_header.startswith("Bearer "):
+                logger.warning("Auth failed: missing or malformed Bearer token from %s", self._client_ip(request))
+                return JSONResponse(status_code=401, content={"detail": "Invalid API key"})
+            token = auth_header[7:]
+            if not hmac.compare_digest(token.encode(), self.api_key.encode()):
+                logger.warning("Auth failed: invalid API key from %s", self._client_ip(request))
+                return JSONResponse(status_code=401, content={"detail": "Invalid API key"})
+        else:
+            client_host = self._client_ip(request)
+            if not self._is_localhost(client_host):
+                logger.warning("Access denied: non-localhost request from %s", client_host)
+                return JSONResponse(status_code=403, content={"detail": "Forbidden: localhost only"})
+
+        return await call_next(request)
+
+    @staticmethod
+    def _client_ip(request: Request) -> str | None:
+        return request.client.host if request.client else None
+
+    @staticmethod
+    def _is_localhost(host: str | None) -> bool:
+        if host is None:
+            return False
+        if host in _LOCALHOST_ADDRESSES:
+            return True
+        # Handle IPv6 scoped addresses like ::1%lo0
+        if host.startswith("::1%"):
+            return True
+        return False

--- a/orchestrator/api/routes.py
+++ b/orchestrator/api/routes.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -151,6 +151,10 @@ class Settings(BaseSettings):
     dashboard_api_timeout: int = 5
     dashboard_api_key: str = ""
 
+    # Dashboard API Server
+    api_port: int = 9000
+    cors_origins: str = ""  # Comma-separated, e.g. "http://localhost:3000"
+
 
 def save_projects(projects: dict[str, dict]) -> None:
     """Write projects dict to projects.json, contracting home dir to ~ for portability."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "anthropic>=0.40",
     "httpx>=0.27",
     "pydantic-settings>=2.0",
+    "fastapi>=0.109",
+    "uvicorn>=0.27",
 ]
 
 [project.optional-dependencies]
@@ -16,6 +18,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "respx>=0.22",
+    "httpx[ws]",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,176 @@
+"""Tests for API Key authentication middleware."""
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.testclient import TestClient as STC
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from orchestrator.api.app import create_api_app
+from orchestrator.api.auth import APIKeyAuthMiddleware
+from orchestrator.config import Settings
+
+
+def _make_settings(**overrides) -> Settings:
+    defaults = dict(
+        telegram_bot_token="fake",
+        telegram_allowed_user_id=1,
+        dashboard_api_key="",
+        cors_origins="",
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+class _FakeClientIP:
+    """ASGI middleware that overrides the client IP in the request scope."""
+
+    def __init__(self, app: ASGIApp, *, host: str, port: int = 12345):
+        self.app = app
+        self.host = host
+        self.port = port
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            scope["client"] = (self.host, self.port)
+        await self.app(scope, receive, send)
+
+
+def _app_with_protected_route(settings: Settings) -> FastAPI:
+    app = create_api_app(settings)
+
+    @app.get("/api/protected")
+    async def protected():
+        return {"ok": True}
+
+    return app
+
+
+# ── A1: Valid API key in Authorization header -> 200 ─────────────────────────
+
+
+def test_valid_api_key_passes():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key="secret123"))
+    client = TestClient(app)
+    resp = client.get("/api/protected", headers={"Authorization": "Bearer secret123"})
+    assert resp.status_code == 200
+
+
+# ── A2: Invalid API key -> 401 ───────────────────────────────────────────────
+
+
+def test_invalid_api_key_returns_401():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key="secret123"))
+    client = TestClient(app)
+    resp = client.get("/api/protected", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid API key"
+
+
+# ── A3: Missing Authorization header, non-localhost -> 403 ───────────────────
+
+
+def test_missing_auth_non_localhost_returns_403():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key=""))
+    wrapped = _FakeClientIP(app, host="192.168.1.100")
+    client = STC(wrapped)
+    resp = client.get("/api/protected")
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Forbidden: localhost only"
+
+
+# ── A4: Missing Authorization header, localhost -> 200 ───────────────────────
+
+
+def test_missing_auth_localhost_allowed():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key=""))
+    wrapped = _FakeClientIP(app, host="127.0.0.1")
+    client = STC(wrapped)
+    resp = client.get("/api/protected")
+    assert resp.status_code == 200
+
+
+# ── A5: Empty DASHBOARD_API_KEY + IPv6 localhost -> 200 ──────────────────────
+
+
+def test_empty_api_key_ipv6_localhost_allowed():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key=""))
+    wrapped = _FakeClientIP(app, host="::1")
+    client = STC(wrapped)
+    resp = client.get("/api/protected")
+    assert resp.status_code == 200
+
+
+# ── A5b: IPv6 scoped localhost (::1%lo0) -> 200 ─────────────────────────────
+
+
+def test_empty_api_key_ipv6_scoped_localhost_allowed():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key=""))
+    wrapped = _FakeClientIP(app, host="::1%lo0")
+    client = STC(wrapped)
+    resp = client.get("/api/protected")
+    assert resp.status_code == 200
+
+
+# ── A6: Empty DASHBOARD_API_KEY + non-localhost -> 403 ───────────────────────
+
+
+def test_empty_api_key_non_localhost_forbidden():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key=""))
+    wrapped = _FakeClientIP(app, host="10.0.0.1")
+    client = STC(wrapped)
+    resp = client.get("/api/protected")
+    assert resp.status_code == 403
+
+
+# ── A7: Bearer prefix is required ────────────────────────────────────────────
+
+
+def test_bearer_prefix_required():
+    app = _app_with_protected_route(_make_settings(dashboard_api_key="secret123"))
+    client = TestClient(app)
+    resp = client.get("/api/protected", headers={"Authorization": "secret123"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid API key"
+
+
+# ── A8: Health endpoint is exempt from auth ──────────────────────────────────
+
+
+def test_health_exempt_from_auth():
+    app = create_api_app(_make_settings(dashboard_api_key="secret123"))
+    client = TestClient(app)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+
+
+# ── A9: Failed auth attempts are logged ──────────────────────────────────────
+
+
+def test_failed_auth_logs_warning(caplog):
+    app = _app_with_protected_route(_make_settings(dashboard_api_key="secret123"))
+    client = TestClient(app)
+    with caplog.at_level(logging.WARNING, logger="orchestrator.api.auth"):
+        client.get("/api/protected", headers={"Authorization": "Bearer wrong"})
+    assert any("auth" in r.message.lower() for r in caplog.records)
+
+
+def test_failed_localhost_check_logs_warning(caplog):
+    app = _app_with_protected_route(_make_settings(dashboard_api_key=""))
+    wrapped = _FakeClientIP(app, host="10.0.0.1")
+    client = STC(wrapped)
+    with caplog.at_level(logging.WARNING, logger="orchestrator.api.auth"):
+        client.get("/api/protected")
+    assert any("forbidden" in r.message.lower() or "denied" in r.message.lower() for r in caplog.records)
+
+
+# ── A10: Constant-time comparison (timing-safe) ─────────────────────────────
+
+
+def test_auth_uses_constant_time_comparison():
+    """Verify the middleware uses hmac.compare_digest (not ==) for key comparison."""
+    import inspect
+    source = inspect.getsource(APIKeyAuthMiddleware.dispatch)
+    assert "compare_digest" in source

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,0 +1,41 @@
+"""Tests for the health endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from orchestrator.api.app import create_api_app
+from orchestrator.config import Settings
+
+
+def _make_settings(**overrides) -> Settings:
+    defaults = dict(
+        telegram_bot_token="fake",
+        telegram_allowed_user_id=1,
+        dashboard_api_key="",
+        cors_origins="",
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+@pytest.fixture()
+def client():
+    app = create_api_app(_make_settings())
+    return TestClient(app)
+
+
+# ── B1: GET /api/health returns 200 with {"status": "ok"} ───────────────────
+
+
+def test_health_returns_ok(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+# ── B2: Response content-type is application/json ────────────────────────────
+
+
+def test_health_content_type(client):
+    resp = client.get("/api/health")
+    assert "application/json" in resp.headers["content-type"]

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,74 @@
+"""Integration tests for API app factory and config."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from orchestrator.api.app import create_api_app
+from orchestrator.config import Settings
+
+
+def _make_settings(**overrides) -> Settings:
+    defaults = dict(
+        telegram_bot_token="fake",
+        telegram_allowed_user_id=1,
+        dashboard_api_key="",
+        cors_origins="",
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+# ── C1: Settings defaults ────────────────────────────────────────────────────
+
+
+def test_settings_defaults():
+    s = _make_settings()
+    assert s.api_port == 9000
+    assert s.cors_origins == ""
+    assert s.dashboard_api_key == ""
+
+
+# ── C2: create_api_app() returns a FastAPI instance ──────────────────────────
+
+
+def test_create_api_app_returns_fastapi():
+    app = create_api_app(_make_settings())
+    assert isinstance(app, FastAPI)
+
+
+# ── C3: CORS middleware is applied when cors_origins is set ──────────────────
+
+
+def test_cors_middleware_applied():
+    app = create_api_app(_make_settings(cors_origins="http://localhost:3000"))
+    middleware_classes = [m.cls.__name__ for m in app.user_middleware]
+    assert "CORSMiddleware" in middleware_classes
+
+
+# ── C4: cors_origins comma-separated string is parsed correctly ──────────────
+
+
+def test_cors_origins_parsing():
+    app = create_api_app(_make_settings(cors_origins="http://a.com, http://b.com ,"))
+    client = TestClient(app)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+
+
+# ── C5: CORS not applied when cors_origins is empty ─────────────────────────
+
+
+def test_cors_not_applied_when_empty():
+    app = create_api_app(_make_settings(cors_origins=""))
+    middleware_classes = [m.cls.__name__ for m in app.user_middleware]
+    assert "CORSMiddleware" not in middleware_classes
+
+
+# ── C6: Invalid CORS origins are filtered out ────────────────────────────────
+
+
+def test_invalid_cors_origins_filtered():
+    app = create_api_app(_make_settings(cors_origins="not-a-url, http://valid.com"))
+    client = TestClient(app)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -13,20 +13,37 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "psutil" },
     { name = "pydantic-settings" },
     { name = "python-telegram-bot", extra = ["all"] },
+    { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
+    { name = "fastapi", specifier = ">=0.109" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", extras = ["ws"], marker = "extra == 'dev'" },
     { name = "psutil", specifier = ">=6.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "python-telegram-bot", extras = ["all"], specifier = ">=22.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
+    { name = "uvicorn", specifier = ">=0.27" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "aiolimiter"
@@ -35,6 +52,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -179,6 +205,27 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -253,6 +300,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833, upload-time = "2026-03-23T14:12:41.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407, upload-time = "2026-03-23T14:12:43.284Z" },
 ]
 
 [[package]]
@@ -341,6 +404,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -423,6 +495,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -589,6 +679,44 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -622,6 +750,18 @@ all = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -637,6 +777,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -698,4 +851,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]


### PR DESCRIPTION
Closes #5

## Design
Now I have full context. Here's the design document.

---

# Design Document: FastAPI Server + API Key Auth Middleware (Issue #5)

## SECTION A: Design Document

### 1. Files to Create/Modify

| Action | Path | Purpose |
|--------|------|---------|
| **Modify** | `pyproject.toml` | Add `fastapi`, `uvicorn` dependencies; add `httpx[ws]` to dev deps for TestClient |
| **Modify** | `orchestrator/config.py` | Add `api_port`, `cors_origins` settings |
| **Modify** | `orchestrator/__main__.py` | Refactor to run bot + FastAPI on same asyncio loop |
| **Create** | `orchestrator/api/__init__.py` | Package init |
| **Create** | `orchestrator/api/app.py` | FastAPI app factory with CORS middleware |
| **Create** | `orchestrator/api/auth.py` | API Key auth middleware (Bearer token + localhost fallback) |
| **Create** | `orchestrator/api/routes.py` | `GET /api/health` endpoint |
| **Create** | `tests/test_api_auth.py` | Auth middleware tests |
| **Create** | `tests/test_api_health.py` | Health endpoint tests |
| **Create** | `tests/test_api_integration.py` | Startup integration (bot + API coexistence) |

---

### 2. TDD Test Plan (Write FIRST)

#### Group A: `tests/test_api_auth.py` — Auth Middleware

```python
# A1: Valid API key in Authorization header → 200
# A2: Invalid API key → 401 with {"detail": "Invalid API key"}
# A3: Missing Authorization header, non-localhost client → 403
# A4: Missing Authorization header, localhost (127.0.0.1) client → 200
# A5: Empty DASHBOARD_API_KEY (no au

_(truncated)_

## Changed Files (10)
- `orchestrator/__main__.py`
- `orchestrator/api/__init__.py`
- `orchestrator/api/app.py`
- `orchestrator/api/auth.py`
- `orchestrator/api/routes.py`
- `orchestrator/config.py`
- `pyproject.toml`
- `tests/test_api_auth.py`
- `tests/test_api_health.py`
- `tests/test_api_integration.py`

## Review
[VERDICT: PASS]


## AI Audit: PASS
[AUDIT: PASS]

## Acceptance Criteria (Sprint Contract)

- [PASS] `fastapi>=0.109` and `uvicorn>=0.27` are listed in `pyproject.toml` dependencies
- [PASS] `Settings` has `api_port: int = 9000` and `cors_origins: str = ""` fields
- [PASS] `orchestrator/api/` package exists with `__init__.py`, `app.py`, `auth.py`, `routes.py`
- [PASS] `GET /api/health` returns `200` with `{"status": "ok"}`
- [PASS] `/api/health` is exempt from authentication (accessible without any credentials)
- [PASS] When `DASHBOARD_API_KEY` is set, requests with valid `Authorization: Bearer <key>` pass auth
- [PASS] When `DASHBOARD_API_KEY` is set, requests with invalid/missing Bearer token receive `401`
- [PASS] When `DASHBOARD_API_KEY` is empty/unset, requests from `127.0.0.1` are allowed
- [PASS] When `DASHBOARD_API_KEY` is empty/unset, requests from non-localhost IPs receive `403`
- [PASS] CORS middleware is applied when `CORS_ORIGINS` env var is non-empty
- [PASS] `__main__.py` runs both Telegram bot polling an

_(truncated)_