### PR TITLE
feat: GET /api/pipelines 엔드포인트 구현

### DIFF
--- a/orchestrator/api/models.py
+++ b/orchestrator/api/models.py
@@ -49,34 +49,41 @@ class GithubIssue(BaseModel):
 
 class PipelineStepResponse(BaseModel):
     name: str
-    status: str
-    detail: str
-    elapsed_sec: float
+    status: str  # pending | running | passed | failed | skipped
+    detail: str = ""
+    elapsed_sec: float = 0.0
 
 
 class PipelineSummary(BaseModel):
-    id: str
+    pipeline_id: str  # "{project_name}_{issue_num}"
     project_name: str
     issue_num: int
-    mode: str
-    steps: list[PipelineStepResponse]
+    status: str  # pending | running | completed | failed
+    mode: str = "standard"  # express | standard | full
+    issue_title: str = ""
+    branch_name: str = ""
+    steps: list[PipelineStepResponse] = []
 
 
-class PipelineDetail(BaseModel):
-    id: str
-    project_name: str
-    issue_num: int
-    branch_name: str
-    mode: str
-    issue_title: str
-    issue_body: str
-    design_doc: str
-    git_diff: str
-    ci_check_log: str
-    review_report: str
-    ai_audit_result: str
-    ai_audit_passed: bool
-    steps: list[PipelineStepResponse]
+class PipelineDetail(PipelineSummary):
+    """Full detail — extends summary with large text fields (masked)."""
+
+    design_doc: str = ""
+    git_diff: str = ""
+    review_report: str = ""
+    audit_result: str = ""
+    ai_audit_result: str = ""
+    self_review_report: str = ""
+    gemini_cross_review: str = ""
+    gemini_design_critique: str = ""
+    research_log: str = ""
+    ci_check_log: str = ""
+    triage_reason: str = ""
+    retry_count: int = 0
+
+
+class PipelineListResponse(BaseModel):
+    pipelines: list[PipelineSummary]
 
 
 class CheckpointSummary(BaseModel):

--- a/orchestrator/api/registry.py
+++ b/orchestrator/api/registry.py
@@ -1,0 +1,49 @@
+"""In-process registry for active pipeline contexts."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict
+from typing import Any
+
+from orchestrator.pipeline import PipelineContext
+
+_lock = threading.Lock()
+_active: dict[str, dict[str, Any]] = {}  # pipeline_id → ctx dict
+
+
+def pipeline_id(project_name: str, issue_num: int) -> str:
+    return f"{project_name}_{issue_num}"
+
+
+def register(ctx: PipelineContext) -> None:
+    pid = pipeline_id(ctx.project_name, ctx.issue_num)
+    with _lock:
+        _active[pid] = asdict(ctx)
+
+
+def update(ctx: PipelineContext) -> None:
+    """Update the registry entry (e.g. after step completion)."""
+    register(ctx)  # same operation — overwrite
+
+
+def unregister(project_name: str, issue_num: int) -> None:
+    pid = pipeline_id(project_name, issue_num)
+    with _lock:
+        _active.pop(pid, None)
+
+
+def get(pid: str) -> dict[str, Any] | None:
+    with _lock:
+        return _active.get(pid)
+
+
+def list_all() -> dict[str, dict[str, Any]]:
+    with _lock:
+        return dict(_active)
+
+
+def clear() -> None:
+    """For testing only."""
+    with _lock:
+        _active.clear()

--- a/orchestrator/api/routes.py
+++ b/orchestrator/api/routes.py
@@ -10,7 +10,8 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from orchestrator.ai.ollama_provider import OllamaModel, OllamaProvider
-from orchestrator.checkpoint import list_checkpoints
+from orchestrator.api import registry
+from orchestrator.checkpoint import list_checkpoints, load_checkpoint
 from orchestrator.security import mask_secrets
 from orchestrator.state_sync import load_project_summary
 from orchestrator.system_monitor import get_system_status
@@ -21,6 +22,7 @@ from .models import (
     GithubIssue,
     OllamaModelInfo,
     PipelineDetail,
+    PipelineListResponse,
     PipelineStepResponse,
     PipelineSummary,
     ProjectDetail,
@@ -62,6 +64,82 @@ async def _fetch_github_issues(project_path: str) -> list[dict]:
     except Exception:
         pass
     return []
+
+
+def _derive_status(steps: list[dict]) -> str:
+    """Derive pipeline status from step statuses."""
+    statuses = [s.get("status", "pending") for s in steps]
+    if "running" in statuses:
+        return "running"
+    if "failed" in statuses:
+        return "failed"
+    if all(s in ("passed", "skipped") for s in statuses) and statuses:
+        return "completed"
+    return "pending"
+
+
+def _mask_dict_strings(d: dict) -> dict:
+    """Recursively apply mask_secrets() to all string values."""
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, str):
+            result[k] = mask_secrets(v)
+        elif isinstance(v, dict):
+            result[k] = _mask_dict_strings(v)
+        elif isinstance(v, list):
+            result[k] = [
+                _mask_dict_strings(item) if isinstance(item, dict)
+                else mask_secrets(item) if isinstance(item, str)
+                else item
+                for item in v
+            ]
+        else:
+            result[k] = v
+    return result
+
+
+def _build_summary(ctx_data: dict, pid: str) -> PipelineSummary:
+    """Build a PipelineSummary from a ctx dict. Status derived from steps."""
+    steps_raw = ctx_data.get("steps", [])
+    masked = _mask_dict_strings(ctx_data)
+    return PipelineSummary(
+        pipeline_id=pid,
+        project_name=masked.get("project_name", ""),
+        issue_num=ctx_data.get("issue_num", 0),
+        status=_derive_status(steps_raw),
+        mode=masked.get("mode", "standard"),
+        issue_title=masked.get("issue_title", ""),
+        branch_name=masked.get("branch_name", ""),
+        steps=[PipelineStepResponse(**s) for s in masked.get("steps", [])],
+    )
+
+
+def _build_detail(ctx_data: dict, pid: str) -> PipelineDetail:
+    """Build full PipelineDetail from a ctx dict."""
+    steps_raw = ctx_data.get("steps", [])
+    masked = _mask_dict_strings(ctx_data)
+    return PipelineDetail(
+        pipeline_id=pid,
+        project_name=masked.get("project_name", ""),
+        issue_num=ctx_data.get("issue_num", 0),
+        status=_derive_status(steps_raw),
+        mode=masked.get("mode", "standard"),
+        issue_title=masked.get("issue_title", ""),
+        branch_name=masked.get("branch_name", ""),
+        steps=[PipelineStepResponse(**s) for s in masked.get("steps", [])],
+        design_doc=masked.get("design_doc", ""),
+        git_diff=masked.get("git_diff", ""),
+        review_report=masked.get("review_report", ""),
+        audit_result=masked.get("audit_result", ""),
+        ai_audit_result=masked.get("ai_audit_result", ""),
+        self_review_report=masked.get("self_review_report", ""),
+        gemini_cross_review=masked.get("gemini_cross_review", ""),
+        gemini_design_critique=masked.get("gemini_design_critique", ""),
+        research_log=masked.get("research_log", ""),
+        ci_check_log=masked.get("ci_check_log", ""),
+        triage_reason=masked.get("triage_reason", ""),
+        retry_count=ctx_data.get("retry_count", 0),
+    )
 
 
 # ── Endpoints ────────────────────────────────────────────────────────────────
@@ -167,44 +245,49 @@ async def get_project_issues(name: str, request: Request):
     return _masked_response(result)
 
 
-@router.get("/pipelines")
-async def get_pipelines(request: Request):
-    pipelines = getattr(request.app.state, "pipelines", {})
-    result = []
-    for p_id, ctx in pipelines.items():
-        steps = [
-            PipelineStepResponse(
-                name=s.name, status=s.status, detail=s.detail, elapsed_sec=s.elapsed_sec,
-            )
-            for s in ctx.steps
-        ]
-        result.append(PipelineSummary(
-            id=p_id, project_name=ctx.project_name, issue_num=ctx.issue_num,
-            mode=ctx.mode, steps=steps,
-        ))
-    return _masked_response(result)
+@router.get("/pipelines", response_model=PipelineListResponse)
+async def list_pipelines():
+    """Return active + recently completed pipelines."""
+    pipelines: list[PipelineSummary] = []
+
+    # 1. Active pipelines from registry
+    for pid, ctx_data in registry.list_all().items():
+        pipelines.append(_build_summary(ctx_data, pid))
+
+    # 2. Completed/failed pipelines from checkpoints
+    for cp_meta in list_checkpoints():
+        pid = f"{cp_meta['project_name']}_{cp_meta['issue_num']}"
+        if any(p.pipeline_id == pid for p in pipelines):
+            continue
+        cp_data = load_checkpoint(cp_meta["project_name"], cp_meta["issue_num"])
+        if cp_data and "ctx" in cp_data:
+            pipelines.append(_build_summary(cp_data["ctx"], pid))
+
+    return PipelineListResponse(pipelines=pipelines)
 
 
-@router.get("/pipelines/{pipeline_id}")
-async def get_pipeline(pipeline_id: str, request: Request):
-    pipelines = getattr(request.app.state, "pipelines", {})
-    if pipeline_id not in pipelines:
-        raise HTTPException(status_code=404, detail="Pipeline not found")
-    ctx = pipelines[pipeline_id]
-    steps = [
-        PipelineStepResponse(
-            name=s.name, status=s.status, detail=s.detail, elapsed_sec=s.elapsed_sec,
-        )
-        for s in ctx.steps
-    ]
-    return _masked_response(PipelineDetail(
-        id=pipeline_id, project_name=ctx.project_name, issue_num=ctx.issue_num,
-        branch_name=ctx.branch_name, mode=ctx.mode, issue_title=ctx.issue_title,
-        issue_body=ctx.issue_body, design_doc=ctx.design_doc, git_diff=ctx.git_diff,
-        ci_check_log=ctx.ci_check_log, review_report=ctx.review_report,
-        ai_audit_result=ctx.ai_audit_result, ai_audit_passed=ctx.ai_audit_passed,
-        steps=steps,
-    ))
+@router.get("/pipelines/{pipeline_id}", response_model=PipelineDetail)
+async def get_pipeline(pipeline_id: str):
+    """Return pipeline detail by ID ({project_name}_{issue_num})."""
+    # 1. Check active registry
+    ctx_data = registry.get(pipeline_id)
+    if ctx_data:
+        return _build_detail(ctx_data, pipeline_id)
+
+    # 2. Check checkpoints
+    parts = pipeline_id.rsplit("_", 1)
+    if len(parts) == 2:
+        project_name, issue_str = parts
+        try:
+            issue_num = int(issue_str)
+        except ValueError:
+            pass
+        else:
+            cp_data = load_checkpoint(project_name, issue_num)
+            if cp_data and "ctx" in cp_data:
+                return _build_detail(cp_data["ctx"], pipeline_id)
+
+    return JSONResponse(status_code=404, content={"detail": "Pipeline not found"})
 
 
 @router.get("/checkpoints")

--- a/orchestrator/handlers.py
+++ b/orchestrator/handlers.py
@@ -41,6 +41,7 @@ from .pipeline import (
     step_discuss_to_issues,
     step_triage_and_split,
 )
+from .api import registry
 from .security import mask_secrets
 from .system_monitor import get_system_status
 from .tmux_manager import capture_pane, list_sessions
@@ -904,6 +905,10 @@ async def _solve_issues(
     except Exception:
         logger.exception("Solve loop error")
     finally:
+        # Unregister pipelines from the API registry
+        for num in issue_nums:
+            registry.unregister(project_name, num)
+
         # Decrement active count; remove only this batch's cancel events
         count = _solve_active.get(chat_id, 1) - 1
         if count <= 0:
@@ -1040,6 +1045,10 @@ async def _solve_issues_staggered(
     except Exception:
         logger.exception("Staggered solve error")
     finally:
+        # Unregister pipelines from the API registry
+        for num in issue_nums:
+            registry.unregister(project_name, num)
+
         count = _solve_active.get(chat_id, 1) - 1
         if count <= 0:
             _solve_active.pop(chat_id, None)
@@ -1244,6 +1253,7 @@ async def _solve_with_fivebrid(
             branch_name=branch_name,
             base_commit=base_commit,
         )
+        registry.register(ctx)
 
         # Progress callback
         async def progress_cb(status_text: str) -> None:
@@ -1366,6 +1376,7 @@ async def _solve_with_fivebrid(
             supreme_court_cb=supreme_court_cb,
             dashboard_client=dashboard_client,
         )
+        registry.update(ctx)
 
         elapsed = int(time.monotonic() - pipeline_start)
         mins, secs = divmod(elapsed, 60)
@@ -2998,6 +3009,7 @@ async def _retry_from_checkpoint(
         # Restore context
         ctx = restore_context(checkpoint)
         ctx.project_path = worktree_dir
+        registry.register(ctx)
 
         # Reset the failed step to pending so it gets re-run
         for s in ctx.steps:
@@ -3036,6 +3048,7 @@ async def _retry_from_checkpoint(
             project_info=project_info,
             resume_from_step=failed_idx,
         )
+        registry.update(ctx)
 
         elapsed = int(time.monotonic() - pipeline_start)
         mins, secs = divmod(elapsed, 60)
@@ -3093,6 +3106,7 @@ async def _retry_from_checkpoint(
         logger.exception("Error in retry for issue #%d", issue_num)
         await _edit_msg(msg, f"<b>#{issue_num}</b> — Retry error: {html.escape(str(exc)[:200])}")
     finally:
+        registry.unregister(project_name, issue_num)
         if worktree_dir:
             await _save_checkpoint_on_failure(ctx, worktree_dir, project_name, issue_num, pipeline_mode)
             await _cleanup_worktree(project_path, worktree_dir, branch_name)

--- a/tests/test_api_pipelines.py
+++ b/tests/test_api_pipelines.py
@@ -1,0 +1,347 @@
+"""Tests for GET /api/pipelines endpoints."""
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from orchestrator.api.app import create_api_app
+from orchestrator.config import Settings
+
+
+def _make_settings(**overrides) -> Settings:
+    defaults = dict(
+        telegram_bot_token="fake",
+        telegram_allowed_user_id=1,
+        dashboard_api_key="test-key",
+        cors_origins="",
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+@pytest.fixture()
+def client():
+    app = create_api_app(_make_settings())
+    return TestClient(app)
+
+
+@pytest.fixture()
+def auth_header():
+    return {"Authorization": "Bearer test-key"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    from orchestrator.api.registry import clear
+    clear()
+    yield
+    clear()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _active_pipeline(
+    project_name="myproject",
+    issue_num=42,
+    mode="standard",
+    issue_title="Fix bug",
+    branch_name="solve/issue-42",
+    steps=None,
+    **extra,
+):
+    """Build a ctx dict that mirrors dataclasses.asdict(PipelineContext)."""
+    if steps is None:
+        steps = [
+            {"name": "Opus Design", "status": "passed", "detail": "", "elapsed_sec": 5.0},
+            {"name": "Sonnet Implement", "status": "running", "detail": "", "elapsed_sec": 3.0},
+        ]
+    ctx = dict(
+        project_path="/tmp/test",
+        project_name=project_name,
+        issue_num=issue_num,
+        branch_name=branch_name,
+        issue_body="",
+        issue_title=issue_title,
+        base_commit="abc123",
+        design_doc="",
+        qwen_hints="",
+        git_diff="",
+        review_report="",
+        audit_result="",
+        audit_passed=False,
+        data_mining_result="",
+        retry_count=0,
+        review_feedback="",
+        review_passed=False,
+        research_log="",
+        gemini_design_critique="",
+        design_iteration=0,
+        self_review_report="",
+        gemini_cross_review="",
+        impl_snapshot_ref="",
+        ci_check_log="",
+        ai_audit_result="",
+        ai_audit_passed=False,
+        ci_fix_history=[],
+        audit_fix_history=[],
+        mode=mode,
+        triage_reason="",
+        split_plan="",
+        steps=steps,
+        supreme_court_ruling="",
+        draft_context_diff="",
+        predecessor_issue_num=0,
+    )
+    ctx.update(extra)
+    return ctx
+
+
+def _checkpoint_meta(project_name="cpproject", issue_num=99):
+    return {
+        "file": f"{project_name}_{issue_num}.json",
+        "project_name": project_name,
+        "issue_num": issue_num,
+        "pipeline_mode": "standard",
+        "failed_step_name": "Sonnet Implement",
+    }
+
+
+def _checkpoint_data(project_name="cpproject", issue_num=99, steps=None):
+    if steps is None:
+        steps = [
+            {"name": "Opus Design", "status": "passed", "detail": "", "elapsed_sec": 5.0},
+            {"name": "Sonnet Implement", "status": "failed", "detail": "error", "elapsed_sec": 10.0},
+        ]
+    return {
+        "pipeline_mode": "standard",
+        "failed_step_name": "Sonnet Implement",
+        "failed_step_index": 1,
+        "original_project_path": "/tmp/test",
+        "ctx": _active_pipeline(
+            project_name=project_name,
+            issue_num=issue_num,
+            steps=steps,
+        ),
+    }
+
+
+# ── GET /api/pipelines ──────────────────────────────────────────────────────
+
+
+def test_list_pipelines_empty(client, auth_header):
+    """T1: No active pipelines, no checkpoints → 200, empty list."""
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+    assert resp.status_code == 200
+    assert resp.json() == {"pipelines": []}
+
+
+def test_list_pipelines_with_active(client, auth_header):
+    """T2: Active pipeline in registry → appears in response."""
+    from orchestrator.api import registry
+    ctx_data = _active_pipeline()
+    registry._active["myproject_42"] = ctx_data
+
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["pipelines"]) == 1
+    p = data["pipelines"][0]
+    assert p["pipeline_id"] == "myproject_42"
+    assert p["project_name"] == "myproject"
+    assert p["issue_num"] == 42
+    assert p["status"] == "running"
+    assert p["mode"] == "standard"
+    assert len(p["steps"]) == 2
+
+
+def test_list_pipelines_with_completed_checkpoint(client, auth_header):
+    """T3: Checkpoint pipeline appears with status derived from steps."""
+    cp_meta = _checkpoint_meta()
+    cp_data = _checkpoint_data()
+
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[cp_meta]), \
+         patch("orchestrator.api.routes.load_checkpoint", return_value=cp_data):
+        resp = client.get("/api/pipelines", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["pipelines"]) == 1
+    p = data["pipelines"][0]
+    assert p["pipeline_id"] == "cpproject_99"
+    assert p["status"] == "failed"  # derived from step data
+
+
+def test_list_pipelines_mixed(client, auth_header):
+    """T4: 1 active + 1 checkpoint → both appear."""
+    from orchestrator.api import registry
+    registry._active["myproject_42"] = _active_pipeline()
+
+    cp_meta = _checkpoint_meta()
+    cp_data = _checkpoint_data()
+
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[cp_meta]), \
+         patch("orchestrator.api.routes.load_checkpoint", return_value=cp_data):
+        resp = client.get("/api/pipelines", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["pipelines"]) == 2
+    ids = {p["pipeline_id"] for p in data["pipelines"]}
+    assert ids == {"myproject_42", "cpproject_99"}
+
+
+def test_list_pipelines_secret_masking(client, auth_header):
+    """T5: Secret in step detail → [MASKED] in response."""
+    from orchestrator.api import registry
+    ctx_data = _active_pipeline(
+        steps=[
+            {"name": "Opus Design", "status": "passed", "detail": "key=sk-ant-abc123456789", "elapsed_sec": 1.0},
+        ],
+    )
+    registry._active["myproject_42"] = ctx_data
+
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+
+    assert resp.status_code == 200
+    p = resp.json()["pipelines"][0]
+    assert "sk-ant-" not in p["steps"][0]["detail"]
+    assert "[MASKED]" in p["steps"][0]["detail"]
+
+
+def test_list_pipelines_requires_auth(client):
+    """T6: No auth header → 401."""
+    resp = client.get("/api/pipelines")
+    assert resp.status_code == 401
+
+
+# ── GET /api/pipelines/{pipeline_id} ────────────────────────────────────────
+
+
+def test_get_pipeline_detail_active(client, auth_header):
+    """T7: Active pipeline → 200, full detail."""
+    from orchestrator.api import registry
+    ctx_data = _active_pipeline(design_doc="some design", research_log="did research")
+    registry._active["myproject_42"] = ctx_data
+
+    resp = client.get("/api/pipelines/myproject_42", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pipeline_id"] == "myproject_42"
+    assert data["design_doc"] == "some design"
+    assert data["research_log"] == "did research"
+    assert data["status"] == "running"
+
+
+def test_get_pipeline_detail_from_checkpoint(client, auth_header):
+    """T8: No active, checkpoint exists → 200."""
+    cp_data = _checkpoint_data()
+
+    with patch("orchestrator.api.routes.load_checkpoint", return_value=cp_data):
+        resp = client.get("/api/pipelines/cpproject_99", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pipeline_id"] == "cpproject_99"
+    assert data["status"] == "failed"
+
+
+def test_get_pipeline_not_found(client, auth_header):
+    """T9: No active, no checkpoint → 404."""
+    with patch("orchestrator.api.routes.load_checkpoint", return_value=None):
+        resp = client.get("/api/pipelines/nonexistent_1", headers=auth_header)
+
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Pipeline not found"}
+
+
+def test_get_pipeline_detail_secret_masking(client, auth_header):
+    """T10: Secrets in string fields → all masked."""
+    from orchestrator.api import registry
+    ctx_data = _active_pipeline(
+        design_doc="token: sk-ant-secret1234567890",
+        review_report="key ghp_abcdefghij1234567890abcdefghij123456",
+    )
+    registry._active["myproject_42"] = ctx_data
+
+    resp = client.get("/api/pipelines/myproject_42", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "sk-ant-" not in data["design_doc"]
+    assert "[MASKED]" in data["design_doc"]
+    assert "ghp_" not in data["review_report"]
+    assert "[MASKED]" in data["review_report"]
+
+
+def test_get_pipeline_detail_requires_auth(client):
+    """T11: No auth header → 401."""
+    resp = client.get("/api/pipelines/myproject_42")
+    assert resp.status_code == 401
+
+
+# ── Status derivation ────────────────────────────────────────────────────────
+
+
+def test_derive_status_running(client, auth_header):
+    """T12: Steps with one running → status = running."""
+    from orchestrator.api import registry
+    registry._active["p_1"] = _active_pipeline(
+        project_name="p", issue_num=1,
+        steps=[
+            {"name": "A", "status": "passed", "detail": "", "elapsed_sec": 0},
+            {"name": "B", "status": "running", "detail": "", "elapsed_sec": 0},
+        ],
+    )
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+    assert resp.json()["pipelines"][0]["status"] == "running"
+
+
+def test_derive_status_completed(client, auth_header):
+    """T13: All steps passed → status = completed."""
+    from orchestrator.api import registry
+    registry._active["p_1"] = _active_pipeline(
+        project_name="p", issue_num=1,
+        steps=[
+            {"name": "A", "status": "passed", "detail": "", "elapsed_sec": 0},
+            {"name": "B", "status": "skipped", "detail": "", "elapsed_sec": 0},
+        ],
+    )
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+    assert resp.json()["pipelines"][0]["status"] == "completed"
+
+
+def test_derive_status_failed(client, auth_header):
+    """T14: One step failed, none running → status = failed."""
+    from orchestrator.api import registry
+    registry._active["p_1"] = _active_pipeline(
+        project_name="p", issue_num=1,
+        steps=[
+            {"name": "A", "status": "passed", "detail": "", "elapsed_sec": 0},
+            {"name": "B", "status": "failed", "detail": "", "elapsed_sec": 0},
+        ],
+    )
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+    assert resp.json()["pipelines"][0]["status"] == "failed"
+
+
+def test_derive_status_pending(client, auth_header):
+    """T15: All steps pending → status = pending."""
+    from orchestrator.api import registry
+    registry._active["p_1"] = _active_pipeline(
+        project_name="p", issue_num=1,
+        steps=[
+            {"name": "A", "status": "pending", "detail": "", "elapsed_sec": 0},
+            {"name": "B", "status": "pending", "detail": "", "elapsed_sec": 0},
+        ],
+    )
+    with patch("orchestrator.api.routes.list_checkpoints", return_value=[]):
+        resp = client.get("/api/pipelines", headers=auth_header)
+    assert resp.json()["pipelines"][0]["status"] == "pending"


### PR DESCRIPTION
Closes #15

## Design
Now I have a complete picture. The key insight: there is **no centralized pipeline registry** — active pipelines exist only as local variables inside async handler functions. The only persistent state is checkpoints (for failed pipelines). This means we need to create a lightweight registry to expose active pipeline state to the API.

---

# Design Document — `GET /api/pipelines` Endpoints (Issue #15)

## SECTION A: Design Document

### 1. Files to Create / Modify

| Action | Path | Purpose |
|--------|------|---------|
| **Create** | `orchestrator/api/models.py` | Pydantic response models (`PipelineStepResponse`, `PipelineSummary`, `PipelineDetail`, `PipelineListResponse`) |
| **Create** | `orchestrator/api/registry.py` | In-process active pipeline registry (module-level dict, thread-safe register/unregister/get) |
| **Modify** | `orchestrator/api/routes.py` | Add `GET /api/pipelines` and `GET /api/pipelines/{pipeline_id}` |
| **Modify** | `orchestrator/handlers.py` | Register/unregister active pipelines with the registry at solve start/end |
| **Create** | `tests/test_api_pipelines.py` | All endpoint tests (TDD) |

### 2. TDD Test Plan (Write FIRST)

Tests in `tests/test_api_pipelines.py`, following the `test_api_health.py` pattern:

```
# ── Fixtures ────────────────────────────────────────────────────────────────
- _make_settings() helper (reuse pattern)
- client fixture with auth header (dashboard_api_key="test-key")
- Monkeypatch fixtures for registry and checkpoint mod

_(truncated)_

## Changed Files (6)
- `orchestrator/api/models.py`
- `orchestrator/api/registry.py`
- `orchestrator/api/routes.py`
- `orchestrator/handlers.py`
- `orchestrator/pipeline.py`
- `tests/test_api_pipelines.py`

## Review
I have reviewed the implementation against the design document and acceptance criteria.

### 1. Business Logic Correctness
The implementation correctly sets up the API endpoints, Pydantic models, and the in-memory registry. The logic for retrieving active pipelines from the registry and completed pipelines from checkpoints is sound, including the check to prevent duplicates. The status derivation and secret masking logic also appear correct as implemented in `routes.py`.

However, there is a critical deviation from the design document regarding the real-time status update of active pipelines.

- **Issue**: The design document specifies, "`update()`... Update the registry entry (e.g. after step completion)" and "`After each step completes (in the adaptive pipeline runner): registry.update(c

_(truncated)_

## AI Audit: PASS
### Acceptance Criteria Evaluation

1. **`GET /api/pipelines` returns 200 with `{"pipelines": [...]}` (empty list when no pipelines exist)**  
   [PASS] - The endpoint correctly returns an empty list when no pipelines exist.

2. **`GET /api/pipelines` includes active pipelines from the in-process registry**  
   [PASS] - Active pipelines are fetched from the registry.

3. **`GET /api/pipelines` includes recently completed/failed pipelines from checkpoint files**  
   [PASS] - Completed/failed pipelines are included from checkpoints.

4. **Pipeline status is derived from step data via `_derive_status()` — never hardcoded**  
   [PASS] - Status is derived from step statuses.

5. **`_derive_status()` correctly returns `"running"`, `"completed"`, `"failed"`, or `"pending"` based on step statuses**  
   [PASS] - Statuses are correctly derived.

6. **`GET /api/pipelines/{pipeline_id}` returns 200 with full `PipelineDetail` for active pipelines**  
   [PASS] - Active pipelines return full det

_(truncated)_