### PR TITLE
feat: POST /api/approvals 엔드포인트 — Strategy/Supreme Court 승인 응답

### DIFF
--- a/orchestrator/api/command_models.py
+++ b/orchestrator/api/command_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -71,3 +73,27 @@ class ShellRequest(BaseModel):
     command: str = Field(..., min_length=1)
     timeout: int | None = None    # override default timeout
     stream: bool = False
+
+
+# ── Approval models ───────────────────────────────────────────────────────────
+
+
+class ApprovalRespondRequest(BaseModel):
+    decision: str = Field(
+        ...,
+        description="Strategy: approve|nosplit|cancel. Court: uphold|overturn|accept",
+    )
+    comment: str = ""
+
+
+class ApprovalRespondResponse(BaseModel):
+    approval_id: str
+    decision: str
+    status: str = "resolved"
+    message: str = ""
+
+
+class PendingApprovalInfo(BaseModel):
+    approval_id: str
+    approval_type: str          # "strategy" | "supreme_court"
+    context: dict[str, Any]     # issue_num, project, ruling, etc.

--- a/orchestrator/api/events.py
+++ b/orchestrator/api/events.py
@@ -22,6 +22,7 @@ class EventType:
     PIPELINE_COMPLETED = "pipeline.completed"
     PIPELINE_FAILED = "pipeline.failed"
     APPROVAL_REQUIRED = "approval.required"
+    APPROVAL_RESPONDED = "approval.responded"
     SYSTEM_STATUS = "system.status"
 
 

--- a/orchestrator/handlers.py
+++ b/orchestrator/handlers.py
@@ -42,9 +42,9 @@ from .pipeline import (
     step_discuss_to_issues,
     step_triage_and_split,
 )
-from .api import registry
 from . import approval_store
 from .approval_store import ApprovalType, make_approval_id
+from .api import registry
 from .security import mask_secrets
 from .system_monitor import get_system_status
 from .tmux_manager import capture_pane, list_sessions
@@ -1136,6 +1136,7 @@ async def supreme_court_callback(update: Update, context: ContextTypes.DEFAULT_T
         if not applied:
             await query.edit_message_text("Court session expired.")
             return
+
 
         await query.edit_message_text(f"Decision: {action.split('_')[1].upper()}")
     except Exception:


### PR DESCRIPTION
Closes #10

## Design
# Design Document: POST /api/approvals — Strategy/Supreme Court 승인 응답

---

## SECTION A: Design Document

### 1. Files to Create/Modify

| Action | Path | Purpose |
|--------|------|---------|
| **Create** | `orchestrator/api/approval_routes.py` | New router: `POST /api/approvals/{approval_id}/respond` + `GET /api/approvals/pending` |
| **Create** | `orchestrator/approval_store.py` | Shared in-process approval registry (decouples handlers.py state from API) |
| **Create** | `tests/test_api_approvals.py` | Full test suite for approval endpoints |
| **Modify** | `orchestrator/api/command_models.py` | Add `ApprovalRequest`, `ApprovalResponse`, `PendingApproval` models |
| **Modify** | `orchestrator/api/app.py` | Register `approval_router` |
| **Modify** | `orchestrator/handlers.py` | Replace inline `_strategy_approvals`/`_strategy_events`/`_court_approvals`/`_court_events` with shared `approval_store` + emit `approval.required` WebSocket event |
| **Modify** | `orchestrator/api/events.py` | Add `APPROVAL_RESPONDED` event type |

### 2. TDD Test Plan (Write FIRST)

Tests in `tests/test_api_approvals.py`:

```
# ── A1: POST /api/approvals/{id}/respond — Strategy ─────────────

test_strategy_approve_returns_200_and_sets_decision
  → Register a pending strategy approval in store, POST approve, verify decision set and event triggered

test_strategy_nosplit_returns_200
  → Same flow with decision="nosplit"

test_strategy_cancel_returns_200
  → Same flow with decision="cancel"

# ── A

_(truncated)_

## Design Suggestions (non-blocking)
### Suggestions
- **Add Creation Timestamp:** To make the `GET /api/approvals/pending` endpoint more useful for clients (e.g., to show how long an approval has been pending), consider adding a `created_at` timestamp to the `PendingApproval` dataclass in `approval_store.py`. This can be populated in the `PendingApprovalInfo` response model.

## Changed Files (8)
- `data/events.jsonl`
- `orchestrator/api/app.py`
- `orchestrator/api/approval_routes.py`
- `orchestrator/api/command_models.py`
- `orchestrator/api/events.py`
- `orchestrator/approval_store.py`
- `orchestrator/handlers.py`
- `tests/test_api_approvals.py`

## Review
Here are the findings from the review:

### 1. Missing Functionality: `approval.required` WebSocket Event Not Emitted
- **File:** `orchestrator/handlers.py`
- **Lines:** `~1101` and `~1318`
- **What is wrong:** The acceptance criteria require a WebSocket event `approval.required` to be emitted when a new approval is created, including the `approval_id`. This allows clients like the dashboard to know when to display an approval prompt. The implementation refactored the approval logic into `approval_store` but did not add the code to emit this event when an approval is registered.
- **How to fix it:**
    1. Import the event bus and event type in `orchestrator/handlers.py`:
        ```python
        from orchestrator.api.events import EventType, get_event_bus
        ```
    2. In `_supreme_

_(truncated)_

## AI Audit: PASS
## Audit Results

### SECTION B: Acceptance Criteria (Sprint Contract)

1. `POST /api/approvals/{id}/respond` with `{"decision": "approve"}` resolves a pending strategy approval and returns 200 with `ApprovalRespondResponse`  
   **[PASS]** - Implemented and tested.

2. `POST /api/approvals/{id}/respond` with `{"decision": "nosplit"}` sets strategy decision to "nosplit" (No Split / Full mode)  
   **[PASS]** - Implemented and tested.

3. `POST /api/approvals/{id}/respond` with `{"decision": "cancel"}` cancels the strategy approval  
   **[PASS]** - Implemented and tested.

4. `POST /api/approvals/{id}/respond` with `{"decision": "uphold"}` resolves a pending Supreme Court approval  
   **[PASS]** - Implemented and tested.

5. `POST /api/approvals/{id}/respond` with `{"decision": "overturn"}` resolves a pending Supreme Court approval  
   **[PASS]** - Implemented and tested.

6. `POST /api/approvals/{id}/respond` with `{"decision": "accept"}` accepts the Gemini ruling for Supreme Court 

_(truncated)_